### PR TITLE
Add warnings for enum cases

### DIFF
--- a/include/swift/AST/DiagnosticsParse.def
+++ b/include/swift/AST/DiagnosticsParse.def
@@ -683,6 +683,10 @@ ERROR(expected_expr_enum_case_raw_value,PointsToFirstBadToken,
       "expected expression after '=' in 'case'", ())
 ERROR(nonliteral_enum_case_raw_value,PointsToFirstBadToken,
       "raw value for enum case must be a literal", ())
+ERROR(empty_enum_type_needs_void,PointsToFirstBadToken,
+      "empty tuple may be unexpected here; use 'Void' explicitly", ())
+WARNING(warn_empty_enum_type_needs_void,PointsToFirstBadToken,
+        "empty tuple may be unexpected here; use 'Void' explicitly", ())
 
 // Collection Types
 ERROR(new_array_syntax,none,

--- a/include/swift/Parse/Parser.h
+++ b/include/swift/Parse/Parser.h
@@ -916,7 +916,7 @@ public:
                                          const TypeAttributes &attrs,
                                          Optional<Scope> &GenericsScope);
   
-  ParserResult<TupleTypeRepr> parseTypeTupleBody();
+  ParserResult<TupleTypeRepr> parseTypeTupleBody(bool ParsingEnumCase = false);
   ParserResult<TypeRepr> parseTypeArray(TypeRepr *Base);
 
   /// Parse a collection type.

--- a/lib/Parse/ParseDecl.cpp
+++ b/lib/Parse/ParseDecl.cpp
@@ -5034,7 +5034,7 @@ Parser::parseDeclEnumCase(ParseDeclOptions Flags,
     // See if there's a following argument type.
     ParserResult<TypeRepr> ArgType;
     if (Tok.isFollowingLParen()) {
-      ArgType = parseTypeTupleBody();
+      ArgType = parseTypeTupleBody(/*ParsingEnumCase*/true);
       if (ArgType.hasCodeCompletion()) {
         Status.setHasCodeCompletion();
         return Status;


### PR DESCRIPTION
Maybe not the best place to do this, but I’m planning on splitting parsing of tuple clauses into its own function anyways.