### PR TITLE
[stdlib] Break infinite recursion false positive in _fatalErrorMessage

### DIFF
--- a/stdlib/public/core/AssertCommon.swift
+++ b/stdlib/public/core/AssertCommon.swift
@@ -168,12 +168,21 @@ internal func _fatalErrorMessage(
   file: StaticString, line: UInt,
   flags: UInt32
 ) -> Never {
+  // This function breaks the infinite recursion detection pass by introducing
+  // a mutually recursive edge.
+  func _withUTF8Buffer<R>(
+    _ string: StaticString, 
+    _ body: (UnsafeBufferPointer<UInt8>) -> R
+  ) {
+    return string.withUTF8Buffer(body)
+  }
+
 #if INTERNAL_CHECKS_ENABLED
-  prefix.withUTF8Buffer {
+  _withUTF8Buffer(prefix) {
     (prefix) in
-    message.withUTF8Buffer {
+    _withUTF8Buffer(message) {
       (message) in
-      file.withUTF8Buffer {
+      _withUTF8Buffer(file) {
         (file) in
         _swift_stdlib_reportFatalErrorInFile(
           prefix.baseAddress!, CInt(prefix.count),
@@ -184,9 +193,9 @@ internal func _fatalErrorMessage(
     }
   }
 #else
-  prefix.withUTF8Buffer {
+  _withUTF8Buffer(prefix) {
     (prefix) in
-    message.withUTF8Buffer {
+    _withUTF8Buffer(message) {
       (message) in
       _swift_stdlib_reportFatalError(
         prefix.baseAddress!, CInt(prefix.count),


### PR DESCRIPTION
Introduce an inner function that breaks the infinite recursion check, silencing this warning:

```
swift/stdlib/public/core/AssertCommon.swift:166:15: warning: all paths through this function will call itself
internal func _fatalErrorMessage(
              ^
```